### PR TITLE
Implement minimalist WebRTC audio call service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # clear-connect
-Privat 1:1 calls
+
+Minimalist 1×1 Audio Call Web Service using WebRTC.
+
+## Development
+
+Build client and server:
+
+```sh
+npm run build
+```
+
+Start server:
+
+```sh
+npm start
+```
+
+Open `http://localhost:3000` in a modern browser. Click **Copy link** to generate a call link and share it with your partner. Opening the link connects automatically.

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -1,0 +1,186 @@
+const statusEl = document.getElementById('status') as HTMLElement;
+const copyBtn = document.getElementById('copyBtn') as HTMLButtonElement;
+const endBtn = document.getElementById('endBtn') as HTMLButtonElement;
+
+let pc: RTCPeerConnection | null = null;
+let localStream: MediaStream | null = null;
+let roomToken: string | null = null;
+const ROOM_TTL_MS = 120000;
+
+function updateStatus(text: string) {
+  statusEl.textContent = text;
+}
+
+function cleanup() {
+  if (pc) {
+    pc.onconnectionstatechange = null;
+    pc.close();
+    pc = null;
+  }
+  if (localStream) {
+    localStream.getTracks().forEach(t => t.stop());
+    localStream = null;
+  }
+}
+
+endBtn.addEventListener('click', () => {
+  cleanup();
+  updateStatus('Call ended');
+});
+
+async function getMic(): Promise<MediaStream | null> {
+  try {
+    return await navigator.mediaDevices.getUserMedia({
+      audio: { echoCancellation: true, noiseSuppression: true, autoGainControl: true }
+    });
+  } catch {
+    updateStatus('Microphone access required');
+    return null;
+  }
+}
+
+function waitForIce(pc: RTCPeerConnection): Promise<void> {
+  return new Promise(resolve => {
+    if (pc.iceGatheringState === 'complete') return resolve();
+    pc.addEventListener('icegatheringstatechange', () => {
+      if (pc.iceGatheringState === 'complete') resolve();
+    });
+  });
+}
+
+async function poll(url: string, ttl: number): Promise<any> {
+  let delay = 500;
+  const end = Date.now() + ttl;
+  while (Date.now() < end) {
+    const resp = await fetch(url);
+    if (resp.status === 200) {
+      return await resp.json();
+    }
+    if (resp.status !== 404) {
+      throw new Error('error');
+    }
+    await new Promise(r => setTimeout(r, delay));
+    delay = Math.min(delay * 2, 2000);
+  }
+  throw new Error('timeout');
+}
+
+async function startInitiator() {
+  const resp = await fetch('/v1/rooms', { method: 'POST' });
+  const data = await resp.json();
+  roomToken = data.token;
+  const joinUrl = data.joinUrl;
+  await navigator.clipboard.writeText(joinUrl);
+  updateStatus('Ready. Send the link to your partner');
+  copyBtn.style.display = 'none';
+  endBtn.style.display = 'inline-block';
+
+  const stream = await getMic();
+  if (!stream) return;
+  localStream = stream;
+
+  pc = new RTCPeerConnection({ iceServers: [{ urls: 'stun:stun.l.google.com:19302' }] });
+  const remoteAudio = new Audio();
+  remoteAudio.autoplay = true;
+  pc.ontrack = ev => { remoteAudio.srcObject = ev.streams[0]; };
+  stream.getTracks().forEach(t => pc!.addTrack(t, stream));
+
+  await pc.setLocalDescription(await pc.createOffer());
+  await waitForIce(pc);
+  await fetch(`/v1/rooms/${roomToken}/offer`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ sdp: pc.localDescription!.sdp })
+  });
+
+  updateStatus('Waiting for answer...');
+  try {
+    const ans = await poll(`/v1/rooms/${roomToken}/answer`, ROOM_TTL_MS);
+    await pc.setRemoteDescription({ type: 'answer', sdp: ans.sdp });
+    updateStatus('Establishing connection...');
+  } catch (e: any) {
+    updateStatus(e.message === 'timeout' ? 'Link expired' : 'Connection failed');
+    cleanup();
+    return;
+  }
+
+  pc.onconnectionstatechange = () => {
+    if (!pc) return;
+    if (pc.connectionState === 'connected') {
+      updateStatus('Connection established');
+    } else if (['failed', 'disconnected', 'closed'].includes(pc.connectionState)) {
+      updateStatus('Call ended');
+    }
+  };
+}
+
+async function startReceiver(token: string) {
+  roomToken = token;
+  copyBtn.style.display = 'none';
+  endBtn.style.display = 'inline-block';
+  updateStatus('Connecting...');
+
+  const stream = await getMic();
+  if (!stream) return;
+  localStream = stream;
+
+  let offerData: any;
+  try {
+    offerData = await poll(`/v1/rooms/${token}/offer`, ROOM_TTL_MS);
+  } catch (e: any) {
+    updateStatus(e.message === 'timeout' ? 'Link expired' : 'Connection failed');
+    return;
+  }
+
+  pc = new RTCPeerConnection({ iceServers: [{ urls: 'stun:stun.l.google.com:19302' }] });
+  const remoteAudio = new Audio();
+  remoteAudio.autoplay = true;
+  pc.ontrack = ev => { remoteAudio.srcObject = ev.streams[0]; };
+  stream.getTracks().forEach(t => pc!.addTrack(t, stream));
+
+  await pc.setRemoteDescription({ type: 'offer', sdp: offerData.sdp });
+  await pc.setLocalDescription(await pc.createAnswer());
+  await waitForIce(pc);
+  const putResp = await fetch(`/v1/rooms/${token}/answer`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ sdp: pc.localDescription!.sdp })
+  });
+  if (putResp.status === 409) {
+    updateStatus('Room occupied');
+    cleanup();
+    return;
+  }
+  if (!putResp.ok) {
+    updateStatus('Link expired');
+    cleanup();
+    return;
+  }
+  updateStatus('Establishing connection...');
+
+  pc.onconnectionstatechange = () => {
+    if (!pc) return;
+    if (pc.connectionState === 'connected') {
+      updateStatus('Connection established');
+    } else if (['failed', 'disconnected', 'closed'].includes(pc.connectionState)) {
+      updateStatus('Call ended');
+    }
+  };
+}
+
+function init() {
+  endBtn.style.display = 'none';
+  const path = window.location.pathname;
+  if (path.startsWith('/room/')) {
+    const token = path.split('/')[2];
+    startReceiver(token);
+  } else {
+    updateStatus('');
+    copyBtn.style.display = 'inline-block';
+    copyBtn.addEventListener('click', () => {
+      startInitiator();
+    });
+  }
+}
+
+init();

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "ES6",
+    "moduleResolution": "node",
+    "outDir": "../public",
+    "rootDir": "src",
+    "lib": ["DOM", "ES2019"],
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "clear-connect",
+  "version": "1.0.0",
+  "description": "Privat 1:1 calls",
+  "main": "index.js",
+  "scripts": {
+    "build:server": "tsc -p server/tsconfig.json",
+    "build:client": "tsc -p client/tsconfig.json",
+    "build": "npm run build:server && npm run build:client",
+    "start": "node server/dist/server.js",
+    "test": "echo \"No tests\""
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Clear Connect</title>
+  <style>
+    body { font-family: sans-serif; text-align: center; margin-top: 40px; }
+    button { padding: 12px 24px; font-size: 16px; margin: 8px; }
+    #status { margin-top: 20px; font-size: 20px; }
+  </style>
+</head>
+<body>
+  <button id="copyBtn" aria-label="Copy link">Copy link</button>
+  <button id="endBtn" aria-label="End">End</button>
+  <div id="status"></div>
+  <script type="module" src="/main.js"></script>
+</body>
+</html>

--- a/public/main.js
+++ b/public/main.js
@@ -1,0 +1,178 @@
+"use strict";
+const statusEl = document.getElementById('status');
+const copyBtn = document.getElementById('copyBtn');
+const endBtn = document.getElementById('endBtn');
+let pc = null;
+let localStream = null;
+let roomToken = null;
+const ROOM_TTL_MS = 120000;
+function updateStatus(text) {
+    statusEl.textContent = text;
+}
+function cleanup() {
+    if (pc) {
+        pc.onconnectionstatechange = null;
+        pc.close();
+        pc = null;
+    }
+    if (localStream) {
+        localStream.getTracks().forEach(t => t.stop());
+        localStream = null;
+    }
+}
+endBtn.addEventListener('click', () => {
+    cleanup();
+    updateStatus('Call ended');
+});
+async function getMic() {
+    try {
+        return await navigator.mediaDevices.getUserMedia({
+            audio: { echoCancellation: true, noiseSuppression: true, autoGainControl: true }
+        });
+    }
+    catch {
+        updateStatus('Microphone access required');
+        return null;
+    }
+}
+function waitForIce(pc) {
+    return new Promise(resolve => {
+        if (pc.iceGatheringState === 'complete')
+            return resolve();
+        pc.addEventListener('icegatheringstatechange', () => {
+            if (pc.iceGatheringState === 'complete')
+                resolve();
+        });
+    });
+}
+async function poll(url, ttl) {
+    let delay = 500;
+    const end = Date.now() + ttl;
+    while (Date.now() < end) {
+        const resp = await fetch(url);
+        if (resp.status === 200) {
+            return await resp.json();
+        }
+        if (resp.status !== 404) {
+            throw new Error('error');
+        }
+        await new Promise(r => setTimeout(r, delay));
+        delay = Math.min(delay * 2, 2000);
+    }
+    throw new Error('timeout');
+}
+async function startInitiator() {
+    const resp = await fetch('/v1/rooms', { method: 'POST' });
+    const data = await resp.json();
+    roomToken = data.token;
+    const joinUrl = data.joinUrl;
+    await navigator.clipboard.writeText(joinUrl);
+    updateStatus('Ready. Send the link to your partner');
+    copyBtn.style.display = 'none';
+    endBtn.style.display = 'inline-block';
+    const stream = await getMic();
+    if (!stream)
+        return;
+    localStream = stream;
+    pc = new RTCPeerConnection({ iceServers: [{ urls: 'stun:stun.l.google.com:19302' }] });
+    const remoteAudio = new Audio();
+    remoteAudio.autoplay = true;
+    pc.ontrack = ev => { remoteAudio.srcObject = ev.streams[0]; };
+    stream.getTracks().forEach(t => pc.addTrack(t, stream));
+    await pc.setLocalDescription(await pc.createOffer());
+    await waitForIce(pc);
+    await fetch(`/v1/rooms/${roomToken}/offer`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sdp: pc.localDescription.sdp })
+    });
+    updateStatus('Waiting for answer...');
+    try {
+        const ans = await poll(`/v1/rooms/${roomToken}/answer`, ROOM_TTL_MS);
+        await pc.setRemoteDescription({ type: 'answer', sdp: ans.sdp });
+        updateStatus('Establishing connection...');
+    }
+    catch (e) {
+        updateStatus(e.message === 'timeout' ? 'Link expired' : 'Connection failed');
+        cleanup();
+        return;
+    }
+    pc.onconnectionstatechange = () => {
+        if (!pc)
+            return;
+        if (pc.connectionState === 'connected') {
+            updateStatus('Connection established');
+        }
+        else if (['failed', 'disconnected', 'closed'].includes(pc.connectionState)) {
+            updateStatus('Call ended');
+        }
+    };
+}
+async function startReceiver(token) {
+    roomToken = token;
+    copyBtn.style.display = 'none';
+    endBtn.style.display = 'inline-block';
+    updateStatus('Connecting...');
+    const stream = await getMic();
+    if (!stream)
+        return;
+    localStream = stream;
+    let offerData;
+    try {
+        offerData = await poll(`/v1/rooms/${token}/offer`, ROOM_TTL_MS);
+    }
+    catch (e) {
+        updateStatus(e.message === 'timeout' ? 'Link expired' : 'Connection failed');
+        return;
+    }
+    pc = new RTCPeerConnection({ iceServers: [{ urls: 'stun:stun.l.google.com:19302' }] });
+    const remoteAudio = new Audio();
+    remoteAudio.autoplay = true;
+    pc.ontrack = ev => { remoteAudio.srcObject = ev.streams[0]; };
+    stream.getTracks().forEach(t => pc.addTrack(t, stream));
+    await pc.setRemoteDescription({ type: 'offer', sdp: offerData.sdp });
+    await pc.setLocalDescription(await pc.createAnswer());
+    await waitForIce(pc);
+    const putResp = await fetch(`/v1/rooms/${token}/answer`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sdp: pc.localDescription.sdp })
+    });
+    if (putResp.status === 409) {
+        updateStatus('Room occupied');
+        cleanup();
+        return;
+    }
+    if (!putResp.ok) {
+        updateStatus('Link expired');
+        cleanup();
+        return;
+    }
+    updateStatus('Establishing connection...');
+    pc.onconnectionstatechange = () => {
+        if (!pc)
+            return;
+        if (pc.connectionState === 'connected') {
+            updateStatus('Connection established');
+        }
+        else if (['failed', 'disconnected', 'closed'].includes(pc.connectionState)) {
+            updateStatus('Call ended');
+        }
+    };
+}
+function init() {
+    endBtn.style.display = 'none';
+    const path = window.location.pathname;
+    if (path.startsWith('/room/')) {
+        const token = path.split('/')[2];
+        startReceiver(token);
+    }
+    else {
+        updateStatus('');
+        copyBtn.style.display = 'inline-block';
+        copyBtn.addEventListener('click', () => {
+            startInitiator();
+        });
+    }
+}
+init();

--- a/server/dist/server.js
+++ b/server/dist/server.js
@@ -1,0 +1,210 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const http_1 = __importDefault(require("http"));
+const crypto_1 = require("crypto");
+const url_1 = require("url");
+const fs_1 = __importDefault(require("fs"));
+const path_1 = __importDefault(require("path"));
+const rooms = new Map();
+const ROOM_TTL_MS = 120_000; // 120s
+const MAX_BODY_SIZE = 1_000_000; // 1 MB
+const rateLimits = new Map();
+function cleanup() {
+    const now = Date.now();
+    for (const [token, room] of rooms) {
+        if (now - room.createdAt > room.ttlMs) {
+            rooms.delete(token);
+        }
+    }
+    for (const [ip, info] of rateLimits) {
+        if (now > info.reset) {
+            rateLimits.delete(ip);
+        }
+    }
+}
+setInterval(cleanup, 5_000);
+function sendJson(res, status, data) {
+    res.writeHead(status, {
+        'Content-Type': 'application/json',
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Methods': 'GET,POST,PUT,OPTIONS',
+        'Access-Control-Allow-Headers': 'Content-Type'
+    });
+    res.end(JSON.stringify(data));
+}
+function sendStatus(res, status) {
+    res.writeHead(status, {
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Methods': 'GET,POST,PUT,OPTIONS',
+        'Access-Control-Allow-Headers': 'Content-Type'
+    });
+    res.end();
+}
+function checkRate(req, res) {
+    const ip = req.socket.remoteAddress || '';
+    const now = Date.now();
+    let info = rateLimits.get(ip);
+    if (!info || now > info.reset) {
+        info = { count: 0, reset: now + 60_000 };
+        rateLimits.set(ip, info);
+    }
+    info.count++;
+    if (info.count > 60) {
+        sendStatus(res, 429);
+        return false;
+    }
+    return true;
+}
+function getRoom(token) {
+    const room = rooms.get(token);
+    if (!room)
+        return undefined;
+    if (Date.now() - room.createdAt > room.ttlMs) {
+        rooms.delete(token);
+        return undefined;
+    }
+    return room;
+}
+async function readJson(req, res) {
+    return new Promise((resolve) => {
+        let data = '';
+        req.on('data', (chunk) => {
+            data += chunk;
+            if (data.length > MAX_BODY_SIZE) {
+                sendStatus(res, 413);
+                req.destroy();
+                resolve(null);
+            }
+        });
+        req.on('end', () => {
+            if (res.writableEnded)
+                return;
+            try {
+                resolve(data ? JSON.parse(data) : {});
+            }
+            catch {
+                sendStatus(res, 400);
+                resolve(null);
+            }
+        });
+    });
+}
+const PUBLIC_DIR = path_1.default.join(__dirname, '../../public');
+const server = http_1.default.createServer(async (req, res) => {
+    if (!req.url)
+        return sendStatus(res, 404);
+    if (!checkRate(req, res))
+        return;
+    if (req.method === 'OPTIONS') {
+        return sendStatus(res, 204);
+    }
+    const url = new url_1.URL(req.url, `http://${req.headers.host}`);
+    if (url.pathname.startsWith('/v1/rooms')) {
+        const match = url.pathname.match(/^\/v1\/rooms\/?$/);
+        if (match && req.method === 'POST') {
+            const token = (0, crypto_1.randomUUID)();
+            const room = { state: 'created', createdAt: Date.now(), ttlMs: ROOM_TTL_MS };
+            rooms.set(token, room);
+            const origin = `http://${req.headers.host}`;
+            sendJson(res, 201, { token, joinUrl: `${origin}/room/${token}`, expiresInSec: ROOM_TTL_MS / 1000 });
+            return;
+        }
+        const subMatch = url.pathname.match(/^\/v1\/rooms\/([a-zA-Z0-9-]+)(?:\/(offer|answer|status))?$/);
+        if (subMatch) {
+            const token = subMatch[1];
+            const action = subMatch[2];
+            const room = getRoom(token);
+            if (!room) {
+                return sendStatus(res, 404);
+            }
+            if (action === 'offer') {
+                if (req.method === 'PUT') {
+                    if (room.state !== 'created')
+                        return sendStatus(res, 409);
+                    const body = await readJson(req, res);
+                    if (!body)
+                        return;
+                    room.offerSDP = body.sdp;
+                    room.state = 'offer_set';
+                    sendStatus(res, 204);
+                }
+                else if (req.method === 'GET') {
+                    if (room.state === 'offer_set' || room.state === 'answer_set') {
+                        sendJson(res, 200, { sdp: room.offerSDP });
+                    }
+                    else {
+                        sendStatus(res, 404);
+                    }
+                }
+                else {
+                    sendStatus(res, 405);
+                }
+                return;
+            }
+            if (action === 'answer') {
+                if (req.method === 'PUT') {
+                    if (room.state !== 'offer_set' || room.answerSDP)
+                        return sendStatus(res, 409);
+                    const body = await readJson(req, res);
+                    if (!body)
+                        return;
+                    room.answerSDP = body.sdp;
+                    room.state = 'answer_set';
+                    sendStatus(res, 204);
+                }
+                else if (req.method === 'GET') {
+                    if (room.state === 'answer_set') {
+                        sendJson(res, 200, { sdp: room.answerSDP });
+                    }
+                    else {
+                        sendStatus(res, 404);
+                    }
+                }
+                else {
+                    sendStatus(res, 405);
+                }
+                return;
+            }
+            if (action === 'status') {
+                if (req.method === 'GET') {
+                    const expiresInSec = Math.max(0, Math.floor((room.createdAt + room.ttlMs - Date.now()) / 1000));
+                    sendJson(res, 200, { state: room.state, expiresInSec });
+                }
+                else {
+                    sendStatus(res, 405);
+                }
+                return;
+            }
+        }
+        return sendStatus(res, 404);
+    }
+    // Static files
+    const serveIndex = () => {
+        const file = path_1.default.join(PUBLIC_DIR, 'index.html');
+        fs_1.default.createReadStream(file).pipe(res);
+    };
+    if (url.pathname === '/' || url.pathname === '/index.html') {
+        res.setHeader('Content-Type', 'text/html');
+        return serveIndex();
+    }
+    if (url.pathname.startsWith('/room/')) {
+        res.setHeader('Content-Type', 'text/html');
+        return serveIndex();
+    }
+    const filePath = path_1.default.join(PUBLIC_DIR, url.pathname);
+    if (fs_1.default.existsSync(filePath) && fs_1.default.statSync(filePath).isFile()) {
+        const ext = path_1.default.extname(filePath);
+        const type = ext === '.js' ? 'text/javascript' : ext === '.css' ? 'text/css' : 'text/plain';
+        res.setHeader('Content-Type', type);
+        fs_1.default.createReadStream(filePath).pipe(res);
+        return;
+    }
+    sendStatus(res, 404);
+});
+const PORT = Number(process.env.PORT || 3000);
+server.listen(PORT, () => {
+    console.log(`Server listening on port ${PORT}`);
+});

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1,0 +1,220 @@
+import http from 'http';
+import { randomUUID } from 'crypto';
+import { URL } from 'url';
+import fs from 'fs';
+import path from 'path';
+
+interface Room {
+  state: 'created' | 'offer_set' | 'answer_set' | 'expired';
+  offerSDP?: string;
+  answerSDP?: string;
+  createdAt: number;
+  ttlMs: number;
+}
+
+const rooms = new Map<string, Room>();
+const ROOM_TTL_MS = 120_000; // 120s
+const MAX_BODY_SIZE = 1_000_000; // 1 MB
+
+const rateLimits = new Map<string, { count: number; reset: number }>();
+
+function cleanup() {
+  const now = Date.now();
+  for (const [token, room] of rooms) {
+    if (now - room.createdAt > room.ttlMs) {
+      rooms.delete(token);
+    }
+  }
+  for (const [ip, info] of rateLimits) {
+    if (now > info.reset) {
+      rateLimits.delete(ip);
+    }
+  }
+}
+setInterval(cleanup, 5_000);
+
+function sendJson(res: any, status: number, data: any) {
+  res.writeHead(status, {
+    'Content-Type': 'application/json',
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Methods': 'GET,POST,PUT,OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type'
+  });
+  res.end(JSON.stringify(data));
+}
+
+function sendStatus(res: any, status: number) {
+  res.writeHead(status, {
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Methods': 'GET,POST,PUT,OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type'
+  });
+  res.end();
+}
+
+function checkRate(req: any, res: any): boolean {
+  const ip = req.socket.remoteAddress || '';
+  const now = Date.now();
+  let info = rateLimits.get(ip);
+  if (!info || now > info.reset) {
+    info = { count: 0, reset: now + 60_000 };
+    rateLimits.set(ip, info);
+  }
+  info.count++;
+  if (info.count > 60) {
+    sendStatus(res, 429);
+    return false;
+  }
+  return true;
+}
+
+function getRoom(token: string): Room | undefined {
+  const room = rooms.get(token);
+  if (!room) return undefined;
+  if (Date.now() - room.createdAt > room.ttlMs) {
+    rooms.delete(token);
+    return undefined;
+  }
+  return room;
+}
+
+async function readJson(req: any, res: any): Promise<any | null> {
+  return new Promise((resolve) => {
+    let data = '';
+    req.on('data', (chunk: any) => {
+      data += chunk;
+      if (data.length > MAX_BODY_SIZE) {
+        sendStatus(res, 413);
+        req.destroy();
+        resolve(null);
+      }
+    });
+    req.on('end', () => {
+      if (res.writableEnded) return;
+      try {
+        resolve(data ? JSON.parse(data) : {});
+      } catch {
+        sendStatus(res, 400);
+        resolve(null);
+      }
+    });
+  });
+}
+
+const PUBLIC_DIR = path.join(__dirname, '../../public');
+
+const server = http.createServer(async (req: any, res: any) => {
+  if (!req.url) return sendStatus(res, 404);
+  if (!checkRate(req, res)) return;
+
+  if (req.method === 'OPTIONS') {
+    return sendStatus(res, 204);
+  }
+
+  const url = new URL(req.url, `http://${req.headers.host}`);
+
+  if (url.pathname.startsWith('/v1/rooms')) {
+    const match = url.pathname.match(/^\/v1\/rooms\/?$/);
+    if (match && req.method === 'POST') {
+      const token = randomUUID();
+      const room: Room = { state: 'created', createdAt: Date.now(), ttlMs: ROOM_TTL_MS };
+      rooms.set(token, room);
+      const origin = `http://${req.headers.host}`;
+      sendJson(res, 201, { token, joinUrl: `${origin}/room/${token}`, expiresInSec: ROOM_TTL_MS / 1000 });
+      return;
+    }
+
+    const subMatch = url.pathname.match(/^\/v1\/rooms\/([a-zA-Z0-9-]+)(?:\/(offer|answer|status))?$/);
+    if (subMatch) {
+      const token = subMatch[1];
+      const action = subMatch[2];
+      const room = getRoom(token);
+      if (!room) {
+        return sendStatus(res, 404);
+      }
+
+      if (action === 'offer') {
+        if (req.method === 'PUT') {
+          if (room.state !== 'created') return sendStatus(res, 409);
+          const body = await readJson(req, res);
+          if (!body) return;
+          room.offerSDP = body.sdp;
+          room.state = 'offer_set';
+          sendStatus(res, 204);
+        } else if (req.method === 'GET') {
+          if (room.state === 'offer_set' || room.state === 'answer_set') {
+            sendJson(res, 200, { sdp: room.offerSDP });
+          } else {
+            sendStatus(res, 404);
+          }
+        } else {
+          sendStatus(res, 405);
+        }
+        return;
+      }
+
+      if (action === 'answer') {
+        if (req.method === 'PUT') {
+          if (room.state !== 'offer_set' || room.answerSDP) return sendStatus(res, 409);
+          const body = await readJson(req, res);
+          if (!body) return;
+          room.answerSDP = body.sdp;
+          room.state = 'answer_set';
+          sendStatus(res, 204);
+        } else if (req.method === 'GET') {
+          if (room.state === 'answer_set') {
+            sendJson(res, 200, { sdp: room.answerSDP });
+          } else {
+            sendStatus(res, 404);
+          }
+        } else {
+          sendStatus(res, 405);
+        }
+        return;
+      }
+
+      if (action === 'status') {
+        if (req.method === 'GET') {
+          const expiresInSec = Math.max(0, Math.floor((room.createdAt + room.ttlMs - Date.now()) / 1000));
+          sendJson(res, 200, { state: room.state, expiresInSec });
+        } else {
+          sendStatus(res, 405);
+        }
+        return;
+      }
+    }
+
+    return sendStatus(res, 404);
+  }
+
+  // Static files
+  const serveIndex = () => {
+    const file = path.join(PUBLIC_DIR, 'index.html');
+    fs.createReadStream(file).pipe(res);
+  };
+
+  if (url.pathname === '/' || url.pathname === '/index.html') {
+    res.setHeader('Content-Type', 'text/html');
+    return serveIndex();
+  }
+  if (url.pathname.startsWith('/room/')) {
+    res.setHeader('Content-Type', 'text/html');
+    return serveIndex();
+  }
+
+  const filePath = path.join(PUBLIC_DIR, url.pathname);
+  if (fs.existsSync(filePath) && fs.statSync(filePath).isFile()) {
+    const ext = path.extname(filePath);
+    const type = ext === '.js' ? 'text/javascript' : ext === '.css' ? 'text/css' : 'text/plain';
+    res.setHeader('Content-Type', type);
+    fs.createReadStream(filePath).pipe(res);
+    return;
+  }
+
+  sendStatus(res, 404);
+});
+
+const PORT = Number(process.env.PORT || 3000);
+server.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});

--- a/server/src/shims.d.ts
+++ b/server/src/shims.d.ts
@@ -1,0 +1,8 @@
+declare module 'http';
+declare module 'crypto';
+declare module 'url';
+declare module 'fs';
+declare module 'path';
+declare var __dirname: string;
+declare var process: any;
+declare var console: any;

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "CommonJS",
+    "rootDir": "src",
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "lib": ["ES2022", "DOM"],
+    "skipLibCheck": true,
+    "noEmitOnError": false
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- build in-memory signaling server with room lifecycle, rate limiting and static file serving
- add TypeScript client for initiator/receiver WebRTC flow with status messages
- document build and run steps in README

## Testing
- `npm run build`
- `node server/dist/server.js` *(server started and was terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68ae9af446e0832fb9020b379f832f4a